### PR TITLE
[Feature] 게시글 생성 API

### DIFF
--- a/src/main/java/com/todaysgym/todaysgym/post/Post.java
+++ b/src/main/java/com/todaysgym/todaysgym/post/Post.java
@@ -5,6 +5,7 @@ import com.todaysgym.todaysgym.member.Member;
 import com.todaysgym.todaysgym.post.comment.Comment;
 import com.todaysgym.todaysgym.post.photo.PostPhoto;
 import com.todaysgym.todaysgym.record.Record;
+import com.todaysgym.todaysgym.record.photo.RecordPhoto;
 import com.todaysgym.todaysgym.utils.BaseTimeEntity;
 import java.util.ArrayList;
 import java.util.List;
@@ -62,5 +63,26 @@ public class Post extends BaseTimeEntity {
 
     public void addReportCount() {
         this.report++;
+    }
+
+    public static Post createPost(Category category, Member writer, String title, String content, Record record){
+        Post post = new Post();
+        post.setCategory(category);
+        post.setRecord(record);
+        post.createTitle(title);
+        post.createContent(content);
+        post.createMember(writer);
+        return post;
+    }
+
+    public void setCategory(Category category) {this.category = category;}
+    public void setRecord(Record record) {this.record = record;}
+    public void createMember(Member member){this.member = member;}
+    public void createContent(String content){this.content = content;}
+    public void createTitle(String title){this.title = title;}
+
+    public void createPhotoList(PostPhoto postPhoto){
+        photoList.add(postPhoto);
+        postPhoto.createPost(this);
     }
 }

--- a/src/main/java/com/todaysgym/todaysgym/post/PostController.java
+++ b/src/main/java/com/todaysgym/todaysgym/post/PostController.java
@@ -1,0 +1,36 @@
+package com.todaysgym.todaysgym.post;
+
+import com.todaysgym.todaysgym.config.response.BaseResponse;
+import com.todaysgym.todaysgym.member.Member;
+import com.todaysgym.todaysgym.post.dto.PostPostReq;
+import com.todaysgym.todaysgym.record.dto.RecordGetReq;
+import com.todaysgym.todaysgym.report.dto.ReportReq;
+import com.todaysgym.todaysgym.utils.UtilService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class PostController {
+
+    private final UtilService utilService;
+    private final PostService postService;
+
+    /** 게시글 생성하기
+     *  [POST] /post
+     */
+    @PostMapping("/post")
+    public BaseResponse<String> createPost(@RequestPart(value = "image", required = false) List<MultipartFile> multipartFiles,
+                                           @RequestPart(value = "postPostReq") @Valid PostPostReq postPostReq){
+            Member writer = utilService.findByMemberIdWithValidation(1L);
+            return new BaseResponse<>(postService.createPost(writer, postPostReq, multipartFiles));
+    }
+
+}

--- a/src/main/java/com/todaysgym/todaysgym/post/PostService.java
+++ b/src/main/java/com/todaysgym/todaysgym/post/PostService.java
@@ -1,12 +1,24 @@
 package com.todaysgym.todaysgym.post;
 
 import com.todaysgym.todaysgym.config.exception.BaseException;
+import com.todaysgym.todaysgym.member.Member;
 import com.todaysgym.todaysgym.post.PostRepository;
+import com.todaysgym.todaysgym.post.dto.PostPostReq;
+import com.todaysgym.todaysgym.post.photo.PostPhotoRepository;
+import com.todaysgym.todaysgym.post.photo.PostPhotoService;
+import com.todaysgym.todaysgym.record.Record;
+import com.todaysgym.todaysgym.record.dto.RecordGetReq;
 import com.todaysgym.todaysgym.record.photo.RecordPhotoRepository;
 import com.todaysgym.todaysgym.record.photo.RecordPhotoService;
+import com.todaysgym.todaysgym.utils.S3Service;
+import com.todaysgym.todaysgym.utils.UtilService;
+import com.todaysgym.todaysgym.utils.dto.getS3Res;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.todaysgym.todaysgym.config.exception.errorCode.RecordErrorCode.EMPTY_RECORD;
@@ -15,11 +27,34 @@ import static com.todaysgym.todaysgym.config.exception.errorCode.RecordErrorCode
 @RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
+    private final PostPhotoService postPhotoService;
+    private final S3Service s3Service;
+    private final UtilService utilService;
 
     /**
      * 기록과 관련된 게시글 조회 후 기록 null로 변경
      */
     public List<Post> deleteRecord(Long recordId){
         return postRepository.findPostByRecord(recordId);
+    }
+
+    @Transactional
+    public String createPost(Member writer, PostPostReq postPostReq, List<MultipartFile> multipartFiles) throws BaseException {
+        // 1. 기록 첨부 여부 조회 -> 기록 없으면 NULL로 저장
+        Record record = null;
+        if(postPostReq.getRecordId() != null) {
+            record = utilService.findByRecordIdWithValidation(postPostReq.getRecordId());
+        }
+        // 2. 게시글 생성
+        Post post = Post.createPost(postPostReq.getCategory(), writer, postPostReq.getTitle(), postPostReq.getContent(), record);
+        postRepository.save(post);
+
+        // 3. 이미지 첨부했다면 저장
+        if(multipartFiles != null) {
+            List<getS3Res> imgUrls = s3Service.uploadFile(multipartFiles);
+            postPhotoService.saveAllPostPhotoByPost(imgUrls, post);
+        }
+
+        return "postId: " + post.getPostId() + "인 게시글을 생성했습니다.";
     }
 }

--- a/src/main/java/com/todaysgym/todaysgym/post/dto/PostPostReq.java
+++ b/src/main/java/com/todaysgym/todaysgym/post/dto/PostPostReq.java
@@ -1,0 +1,4 @@
+package com.todaysgym.todaysgym.post.dto;
+
+public class PostPostReq {
+}

--- a/src/main/java/com/todaysgym/todaysgym/post/dto/PostPostReq.java
+++ b/src/main/java/com/todaysgym/todaysgym/post/dto/PostPostReq.java
@@ -1,4 +1,23 @@
 package com.todaysgym.todaysgym.post.dto;
 
+import com.todaysgym.todaysgym.category.Category;
+import com.todaysgym.todaysgym.tag.Tag;
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
 public class PostPostReq {
+    @NotNull
+    private Category category;
+    @NotBlank
+    private String title;
+    @NotBlank
+    private String content;
+
+    private Long recordId; // null 일 수도 있음
+
 }

--- a/src/main/java/com/todaysgym/todaysgym/post/photo/PostPhoto.java
+++ b/src/main/java/com/todaysgym/todaysgym/post/photo/PostPhoto.java
@@ -9,12 +9,16 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+
+import com.todaysgym.todaysgym.record.Record;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "post_photo")
@@ -30,4 +34,8 @@ public class PostPhoto {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
+
+    public void createPost(Post post){
+        this.post = post;
+    }
 }

--- a/src/main/java/com/todaysgym/todaysgym/post/photo/PostPhotoRepository.java
+++ b/src/main/java/com/todaysgym/todaysgym/post/photo/PostPhotoRepository.java
@@ -1,7 +1,22 @@
 package com.todaysgym.todaysgym.post.photo;
 
+import com.todaysgym.todaysgym.record.photo.RecordPhoto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface PostPhotoRepository extends JpaRepository<PostPhoto, Long> {
 
+    @Query("SELECT pp FROM PostPhoto pp WHERE pp.post.postId = :postId")
+    List<PostPhoto> findAllByPost(@Param("postId") Long postId);
+
+    @Query("SELECT pp.id FROM PostPhoto pp WHERE pp.post.postId = :postId")
+    List<Long> findAllId(@Param("postId") Long postId);
+
+    @Modifying
+    @Query("DELETE FROM PostPhoto pp WHERE pp.id IN :ids")
+    Integer deleteAllByPost(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/todaysgym/todaysgym/post/photo/PostPhotoService.java
+++ b/src/main/java/com/todaysgym/todaysgym/post/photo/PostPhotoService.java
@@ -1,0 +1,66 @@
+package com.todaysgym.todaysgym.post.photo;
+
+import com.todaysgym.todaysgym.post.Post;
+import com.todaysgym.todaysgym.record.photo.RecordPhoto;
+import com.todaysgym.todaysgym.utils.S3Service;
+import com.todaysgym.todaysgym.utils.dto.getS3Res;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class PostPhotoService {
+
+    private final PostPhotoRepository postPhotoRepository;
+    private final S3Service s3Service;
+
+    @Transactional
+    public void savePostPhoto(List<PostPhoto> postPhotos){
+        postPhotoRepository.saveAll(postPhotos);
+    }
+
+    public List<PostPhoto> findByPostId(Long postId){ return postPhotoRepository.findAllByPost(postId); }
+
+    /**
+     *  여러개의 postPhoto 저장
+     */
+    @Transactional
+    public void saveAllPostPhotoByPost(List<getS3Res> getS3ResList, Post post) {
+        List<PostPhoto> postPhotos = new ArrayList<>();
+        for(getS3Res getS3Res : getS3ResList){
+            PostPhoto postPhoto = PostPhoto.builder()
+                    .imgUrl(getS3Res.getImgUrl())
+                    .fileName(getS3Res.getFileName())
+                    .build();
+            postPhotos.add(postPhoto);
+            post.createPhotoList(postPhoto);
+        }
+        savePostPhoto(postPhotos);
+    }
+
+    /**
+     * 게시글과 연관된 모든 postPhoto 삭제
+     */
+    @Transactional
+    public void deleteAllPostPhotos(List<PostPhoto> postPhotos){
+        for (PostPhoto postPhoto : postPhotos) {
+            s3Service.deleteFile(postPhoto.getFileName());
+        }
+    }
+
+    @Transactional
+    public void deleteAllPostPhotoByPost(List<Long> ids){
+        postPhotoRepository.deleteAllByPost(ids);
+    }
+
+    /**
+     * post와 연관된 모든 id 조회
+     */
+    public List<Long> findAllId(Long postId){
+        return postPhotoRepository.findAllId(postId);
+    }
+}


### PR DESCRIPTION
### 체크리스트(PR 올리기 전 아래 내용을 확인해주세요)
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] 리뷰가 필요할 경우 리뷰어를 적용했나요?
- [x] pr 제목을 규칙에 맞게 작성했나요?
- [x] 이슈 번호를 기록했나요?
- [x] 라벨을 지정했나요?

### 이슈 번호
close https://github.com/Today-s-Gym/backend/issues/38

### 구현 기능
- Post 생성
- Post에 PostPhoto 첨부 시 S3에 등록 및 삭제 기능

### 논의 하고 싶은 내용
- 저는 평소에 Entity 만들 때 Builder 패턴을 자주 사용하는 편인데, 다른 분들 코드를 보니 Entity class 밑에 생성자와 각종 메서드를 만들어서 생성자를 통해 Entity를 생성하시더라고요! 그래서 두 가지 방식의 차이가 궁금해져 알아보았습니다. 여러분들은 Builder를 사용하지 않고 생성자로 만드는 특별한 이유가 있으신가요?
- Builder 패턴은 생성자 방식의 단점을 보완하기 위해 만들어졌다고 합니다. 파라미터로 넘겨주는 인자값이 많아지고 자료형이 다양해질 경우 생성자 보다는 Builder를 추천한다고 합니다. 넘겨줄 인자가 많을 때 생성자로 만들면 순서를 꼭 지켜주어야 하기 때문에 혼란이 올 수 있는 반면, Builder 패턴을 이용하면 네임드 파라미터를 사용할 수 있고 안전하다고 합니다.
- 오늘의 짐 레포지토리를 옮기기 전에는 게시글 생성 API를 Builder 패턴으로 구현했었습니다. 이번에는 생성자를 사용하여 구현해보았습니다. 빌더를 사용한 코드가 가독성이 더 좋은 것 같은데, 생성자를 이용해 구현하니 코드가 훨씬 깔끔하다는 느낌을 받았습니다!
- 그런데 이런 의문이 들었습니다. Builder가 생성자의 단점을 보완한다면, Builder만 쓰면 되지 않을까요? 왜 섞어 쓰는 걸까요..? 여러분의 생각이 궁금합니다!

### 공유하고 싶은 내용
- PostPhoto 관련해서 헤론의 방식과 비슷하게 하려고 로직을 많이 참고했습니다 하하 감사합니다 헤론 최고에요!
